### PR TITLE
fix: Carga mes por defecto del reporte seleccionado

### DIFF
--- a/src/app/encuestas/componentes/encuesta-cuantitativa/tab-encuesta-cuantitativa/tab-encuesta-cuantitativa.component.html
+++ b/src/app/encuestas/componentes/encuesta-cuantitativa/tab-encuesta-cuantitativa/tab-encuesta-cuantitativa.component.html
@@ -2,19 +2,23 @@
     <ul class="subindicadores">
         <li class="cabeceras-subindicador">
             <div class="row">
-                <div class="col-1">Variable del indicador</div>
+                <div class="col-2">Variable del indicador</div>
                 <div class="col-4">Indicadores</div>
-                <div class="col-7">Valores</div>
+                <div class="col-6">Valores</div>
             </div>
         </li>
         <li class="fondo-gris-1 p-3" *ngIf="subindicadores.length < 1">
             {{ mensaje }}
         </li>
         <li class="subindicador" *ngFor="let subindicador of subindicadores">
-            <app-subindicador-encuesta-cuantitativa [preguntasFaltantes]="indicadoresFaltantes"
-                [soloLectura]="soloLectura" [habilitarCamposVerificador]="habilitarCamposVerificador"
-                [habilitarCamposVigilado]="habilitarCamposVigilado" [subindicador]="subindicador"
-                [estadoRespuestas]="estadoRespuestas" (nuevaRespuesta)="manejarNuevaRespuesta($event)" />
+            <app-subindicador-encuesta-cuantitativa 
+                [preguntasFaltantes]="indicadoresFaltantes"
+                [soloLectura]="soloLectura" 
+                [habilitarCamposVerificador]="habilitarCamposVerificador"
+                [habilitarCamposVigilado]="habilitarCamposVigilado" 
+                [subindicador]="subindicador"
+                [estadoRespuestas]="estadoRespuestas" 
+                (nuevaRespuesta)="manejarNuevaRespuesta($event)" />
         </li>
     </ul>
 </div>
@@ -38,10 +42,14 @@
                 <div class="col-3">{{ evidencia.nombre }}</div>
                 <div class="col-2">{{ evidencia.validaciones.tipoDato }}</div>
                 <div class="col-2">
-                    <app-evidencia-encuesta-cuantitativa [nombreFormulario]="nombreFormulario"
-                        [soloLectura]="soloLectura" [habilitarCamposVerificador]="habilitarCamposVerificador"
-                        [habilitarCamposVigilado]="habilitarCamposVigilado" [idVigilado]="idVigilado"
-                        [evidencia]="evidencia" (evidenciaExcedeTamano)="manejarEvidenciaExcedeTamano($event)"
+                    <app-evidencia-encuesta-cuantitativa 
+                        [nombreFormulario]="nombreFormulario"
+                        [soloLectura]="soloLectura" 
+                        [habilitarCamposVerificador]="habilitarCamposVerificador"
+                        [habilitarCamposVigilado]="habilitarCamposVigilado" 
+                        [idVigilado]="idVigilado"
+                        [evidencia]="evidencia" 
+                        (evidenciaExcedeTamano)="manejarEvidenciaExcedeTamano($event)"
                         (errorAlCargar)="manejarErrorAlCargar($event)"
                         (nuevaEvidencia)="manejarNuevaEvidencia($event)" />
                 </div>

--- a/src/app/encuestas/paginas/pagina-encuesta/pagina-encuesta.component.html
+++ b/src/app/encuestas/paginas/pagina-encuesta/pagina-encuesta.component.html
@@ -122,7 +122,7 @@
         *ngIf="idEncuesta == 2 && encuestaCuantitativa" 
         [encuesta]="encuestaCuantitativa"
         [historico]="historico"
-        (cambioDeMes)="obtenerEncuestaCuantitativa($event)"
+        (cambioDeMes)="($event)"
         (hanHabidoCambios)="setHayCambios($event)"
         (formularioGuardado)="manejarFormularioGuardado($event)"
         />

--- a/src/app/verificaciones/paginas/pagina-reporte-fase2-verificar/pagina-reporte-fase2-verificar.component.html
+++ b/src/app/verificaciones/paginas/pagina-reporte-fase2-verificar/pagina-reporte-fase2-verificar.component.html
@@ -101,7 +101,12 @@
             [routerLink]="['/administrar', 'verificar-reportes', 'fase-dos', 'reportes']">Volver</button>
     </div>
 
-    <app-encuesta-cuantitativa #encuesta [encuesta]="reporte" [historico]="historico" [habilitarCamposVigilado]="false"
-        [habilitarCamposVerificador]="true" (cambioDeMes)="obtenerReporte($event)"
-        (hanHabidoCambios)="setHayCambios($event)" (formularioGuardado)="manejarFormularioGuardado($event)" />
+    <app-encuesta-cuantitativa #encuesta 
+        [encuesta]="reporte" 
+        [historico]="historico" 
+        [habilitarCamposVigilado]="false"
+        [habilitarCamposVerificador]="true" 
+        (cambioDeMes)="obtenerReporte($event)"
+        (hanHabidoCambios)="setHayCambios($event)" 
+        (formularioGuardado)="manejarFormularioGuardado($event)" />
 </div>

--- a/src/app/verificaciones/paginas/pagina-reporte-fase2-verificar/pagina-reporte-fase2-verificar.component.ts
+++ b/src/app/verificaciones/paginas/pagina-reporte-fase2-verificar/pagina-reporte-fase2-verificar.component.ts
@@ -4,6 +4,7 @@ import { ServicioVerificaciones } from '../../servicios/verificaciones.service';
 import { ActivatedRoute, Params } from '@angular/router';
 import { combineLatest } from 'rxjs'
 import { EncuestaCuantitativaComponent } from 'src/app/encuestas/componentes/encuesta-cuantitativa/encuesta-cuantitativa/encuesta-cuantitativa.component';
+import { ServicioEncuestas } from 'src/app/encuestas/servicios/encuestas.service';
 
 @Component({
   selector: 'app-pagina-reporte-fase2-verificar',
@@ -22,14 +23,21 @@ export class PaginaReporteFase2VerificarComponent {
   hayCambios: boolean = false
   soloLectura: boolean = false
 
-  constructor(private servicioVerificacion: ServicioVerificaciones, private activedRoute: ActivatedRoute){
+  constructor(
+    private servicioVerificacion: ServicioVerificaciones,
+    private servicioEncuesta: ServicioEncuestas, 
+    private activedRoute: ActivatedRoute){
     combineLatest({
       parametros: this.activedRoute.params, 
       query: this.activedRoute.queryParams
     }).subscribe({
       next: ({ parametros, query})=>{
         this.recogerParametrosUrl(parametros, query)
-        this.obtenerReporte(this.idMes!)
+        this.servicioEncuesta.obtenerMeses(this.vigencia!,this.historico).subscribe({
+          next: (respuesta) => {
+            this.obtenerReporte(respuesta.meses[0].idMes)
+          }
+        })
       }
     })
   }


### PR DESCRIPTION
No se estaba enviando el id del mes que aparecía por defecto al momento de cargar algún reporte en fase 2, así que se hizo la corrección pertinente.